### PR TITLE
feat: implement authentication & role-based access (issue #1)

### DIFF
--- a/Itenium.SkillForge/backend/Itenium.SkillForge.Data/SeedData.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.Data/SeedData.cs
@@ -142,6 +142,7 @@ public static class SeedData
             if (result.Succeeded)
             {
                 await userManager.AddToRoleAsync(user, "learner");
+                await userManager.AddClaimAsync(user, new Claim("team", "1")); // Java team
             }
         }
     }

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.Services/IUserService.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.Services/IUserService.cs
@@ -1,0 +1,20 @@
+namespace Itenium.SkillForge.Services;
+
+public record UserDto(string Id, string UserName, string Email, string FirstName, string LastName, string Role, int[] Teams);
+
+public record CreateUserRequest(string UserName, string Email, string Password, string FirstName, string LastName, string Role, int[] Teams);
+
+public record AssignRoleRequest(string Role);
+
+public record AssignTeamsRequest(int[] TeamIds);
+
+public interface IUserService
+{
+    Task<IList<UserDto>> GetAllUsersAsync();
+    Task<IList<UserDto>> GetTeamMembersAsync(int[] teamIds);
+    Task<IList<UserDto>> GetCoachesForTeamsAsync(int[] teamIds);
+    Task<UserDto?> GetUserByIdAsync(string userId);
+    Task<UserDto?> CreateUserAsync(CreateUserRequest request);
+    Task<bool> AssignRoleAsync(string userId, string role);
+    Task<bool> AssignTeamsAsync(string userId, int[] teamIds);
+}

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.Services/IUserService.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.Services/IUserService.cs
@@ -4,6 +4,16 @@ public record UserDto(string Id, string UserName, string Email, string FirstName
 
 public record CreateUserRequest(string UserName, string Email, string Password, string FirstName, string LastName, string Role, int[] Teams);
 
+public record UserError(string Code, string Description);
+
+public record CreateUserResult(UserDto? User, IReadOnlyList<UserError> Errors)
+{
+    public bool Succeeded => User != null;
+
+    public static CreateUserResult Success(UserDto user) => new(user, []);
+    public static CreateUserResult Failure(IReadOnlyList<UserError> errors) => new(null, errors);
+}
+
 public record AssignRoleRequest(string Role);
 
 public record AssignTeamsRequest(int[] TeamIds);
@@ -14,7 +24,7 @@ public interface IUserService
     Task<IList<UserDto>> GetTeamMembersAsync(int[] teamIds);
     Task<IList<UserDto>> GetCoachesForTeamsAsync(int[] teamIds);
     Task<UserDto?> GetUserByIdAsync(string userId);
-    Task<UserDto?> CreateUserAsync(CreateUserRequest request);
+    Task<CreateUserResult> CreateUserAsync(CreateUserRequest request);
     Task<bool> AssignRoleAsync(string userId, string role);
     Task<bool> AssignTeamsAsync(string userId, int[] teamIds);
 }

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
@@ -171,7 +171,7 @@ public class UserControllerTests
     public async Task CreateUser_ReturnsCreatedUser()
     {
         var request = new CreateUserRequest("alice", "alice@test.local", "Pass123!", "Alice", "Smith", "learner", [1]);
-        _userService.CreateUserAsync(request).Returns(Alice);
+        _userService.CreateUserAsync(request).Returns(CreateUserResult.Success(Alice));
 
         var result = await _sut.CreateUser(request);
 
@@ -181,14 +181,17 @@ public class UserControllerTests
     }
 
     [Test]
-    public async Task CreateUser_WhenServiceReturnsNull_ReturnsBadRequest()
+    public async Task CreateUser_WhenServiceFails_ReturnsBadRequestWithErrors()
     {
         var request = new CreateUserRequest("alice", "alice@test.local", "weak", "Alice", "Smith", "learner", []);
-        _userService.CreateUserAsync(request).Returns((UserDto?)null);
+        var errors = new[] { new UserError("PasswordTooShort", "Password must be at least 8 characters.") };
+        _userService.CreateUserAsync(request).Returns(CreateUserResult.Failure(errors));
 
         var result = await _sut.CreateUser(request);
 
-        Assert.That(result.Result, Is.TypeOf<BadRequestResult>());
+        var badRequest = result.Result as BadRequestObjectResult;
+        Assert.That(badRequest, Is.Not.Null);
+        Assert.That(badRequest!.Value, Is.InstanceOf<IReadOnlyList<UserError>>());
     }
 
     // PUT /api/user/{id}/role

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
@@ -15,6 +15,8 @@ public class UserControllerTests
     private static readonly UserDto Alice = new("id1", "alice", "alice@test.local", "Alice", "Smith", "learner", [1]);
     private static readonly UserDto Bob = new("id2", "bob", "bob@test.local", "Bob", "Jones", "manager", [1, 2]);
     private static readonly UserDto Charlie = new("id3", "charlie", "charlie@test.local", "Charlie", "Brown", "backoffice", []);
+    private static readonly int[] TeamIds1 = [1];
+    private static readonly int[] TeamIds12 = [1, 2];
 
     [SetUp]
     public void Setup()
@@ -45,8 +47,8 @@ public class UserControllerTests
     {
         IList<UserDto> teamMembers = [Alice, Bob];
         _currentUser.IsBackOffice.Returns(false);
-        _currentUser.Teams.Returns(new[] { 1, 2 });
-        _userService.GetTeamMembersAsync([1, 2]).Returns(teamMembers);
+        _currentUser.Teams.Returns(TeamIds12);
+        _userService.GetTeamMembersAsync(TeamIds12).Returns(teamMembers);
 
         var result = await _sut.GetUsers();
 
@@ -77,8 +79,8 @@ public class UserControllerTests
     {
         IList<UserDto> teamMembers = [Alice];
         _currentUser.IsBackOffice.Returns(false);
-        _currentUser.Teams.Returns(new[] { 1 });
-        _userService.GetTeamMembersAsync([1]).Returns(teamMembers);
+        _currentUser.Teams.Returns(TeamIds1);
+        _userService.GetTeamMembersAsync(TeamIds1).Returns(teamMembers);
 
         var result = await _sut.GetUsers();
 
@@ -118,8 +120,8 @@ public class UserControllerTests
     public async Task GetCoaches_WhenUserHasTeams_ReturnsCoaches()
     {
         IList<UserDto> coaches = [Bob];
-        _currentUser.Teams.Returns(new[] { 1 });
-        _userService.GetCoachesForTeamsAsync([1]).Returns(coaches);
+        _currentUser.Teams.Returns(TeamIds1);
+        _userService.GetCoachesForTeamsAsync(TeamIds1).Returns(coaches);
 
         var result = await _sut.GetCoaches();
 

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi.Tests/UserControllerTests.cs
@@ -1,0 +1,235 @@
+using Itenium.SkillForge.Services;
+using Itenium.SkillForge.WebApi.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+
+namespace Itenium.SkillForge.WebApi.Tests;
+
+[TestFixture]
+public class UserControllerTests
+{
+    private IUserService _userService = null!;
+    private ISkillForgeUser _currentUser = null!;
+    private UserController _sut = null!;
+
+    private static readonly UserDto Alice = new("id1", "alice", "alice@test.local", "Alice", "Smith", "learner", [1]);
+    private static readonly UserDto Bob = new("id2", "bob", "bob@test.local", "Bob", "Jones", "manager", [1, 2]);
+    private static readonly UserDto Charlie = new("id3", "charlie", "charlie@test.local", "Charlie", "Brown", "backoffice", []);
+
+    [SetUp]
+    public void Setup()
+    {
+        _userService = Substitute.For<IUserService>();
+        _currentUser = Substitute.For<ISkillForgeUser>();
+        _sut = new UserController(_userService, _currentUser);
+    }
+
+    // GET /api/user — role-aware
+
+    [Test]
+    public async Task GetUsers_WhenBackOffice_ReturnsAllUsers()
+    {
+        IList<UserDto> all = [Alice, Bob, Charlie];
+        _currentUser.IsBackOffice.Returns(true);
+        _userService.GetAllUsersAsync().Returns(all);
+
+        var result = await _sut.GetUsers();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        Assert.That(ok!.Value as IList<UserDto>, Has.Count.EqualTo(3));
+    }
+
+    [Test]
+    public async Task GetUsers_WhenManager_ReturnsTeamMembers()
+    {
+        IList<UserDto> teamMembers = [Alice, Bob];
+        _currentUser.IsBackOffice.Returns(false);
+        _currentUser.Teams.Returns(new[] { 1, 2 });
+        _userService.GetTeamMembersAsync([1, 2]).Returns(teamMembers);
+
+        var result = await _sut.GetUsers();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        Assert.That(ok!.Value as IList<UserDto>, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public async Task GetUsers_WhenLearnerWithNoTeams_ReturnsSelf()
+    {
+        _currentUser.IsBackOffice.Returns(false);
+        _currentUser.Teams.Returns(Array.Empty<int>());
+        _currentUser.UserId.Returns("id1");
+        _userService.GetUserByIdAsync("id1").Returns(Alice);
+
+        var result = await _sut.GetUsers();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        var users = ok!.Value as IList<UserDto>;
+        Assert.That(users, Has.Count.EqualTo(1));
+        Assert.That(users![0].Id, Is.EqualTo("id1"));
+    }
+
+    [Test]
+    public async Task GetUsers_WhenLearnerWithTeam_ReturnsTeamMembers()
+    {
+        IList<UserDto> teamMembers = [Alice];
+        _currentUser.IsBackOffice.Returns(false);
+        _currentUser.Teams.Returns(new[] { 1 });
+        _userService.GetTeamMembersAsync([1]).Returns(teamMembers);
+
+        var result = await _sut.GetUsers();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That((ok!.Value as IList<UserDto>)![0].Id, Is.EqualTo("id1"));
+    }
+
+    // GET /api/user/me
+
+    [Test]
+    public async Task GetCurrentUser_ReturnsCurrentUserInfo()
+    {
+        _currentUser.UserId.Returns("id1");
+        _userService.GetUserByIdAsync("id1").Returns(Alice);
+
+        var result = await _sut.GetCurrentUser();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        Assert.That(ok!.Value, Is.EqualTo(Alice));
+    }
+
+    [Test]
+    public async Task GetCurrentUser_WhenUserNotFound_ReturnsNotFound()
+    {
+        _currentUser.UserId.Returns("missing");
+        _userService.GetUserByIdAsync("missing").Returns((UserDto?)null);
+
+        var result = await _sut.GetCurrentUser();
+
+        Assert.That(result.Result, Is.TypeOf<NotFoundResult>());
+    }
+
+    // GET /api/user/coach
+
+    [Test]
+    public async Task GetCoaches_WhenUserHasTeams_ReturnsCoaches()
+    {
+        IList<UserDto> coaches = [Bob];
+        _currentUser.Teams.Returns(new[] { 1 });
+        _userService.GetCoachesForTeamsAsync([1]).Returns(coaches);
+
+        var result = await _sut.GetCoaches();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        Assert.That(ok!.Value as IList<UserDto>, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetCoaches_WhenUserHasNoTeams_ReturnsEmpty()
+    {
+        _currentUser.Teams.Returns(Array.Empty<int>());
+
+        var result = await _sut.GetCoaches();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok, Is.Not.Null);
+        Assert.That(ok!.Value as IList<UserDto>, Is.Empty);
+    }
+
+    // GET /api/user/{id}
+
+    [Test]
+    public async Task GetUserById_ReturnsUser()
+    {
+        _userService.GetUserByIdAsync("id1").Returns(Alice);
+
+        var result = await _sut.GetUserById("id1");
+
+        var ok = result.Result as OkObjectResult;
+        Assert.That(ok!.Value, Is.EqualTo(Alice));
+    }
+
+    [Test]
+    public async Task GetUserById_WhenNotFound_ReturnsNotFound()
+    {
+        _userService.GetUserByIdAsync("missing").Returns((UserDto?)null);
+
+        var result = await _sut.GetUserById("missing");
+
+        Assert.That(result.Result, Is.TypeOf<NotFoundResult>());
+    }
+
+    // POST /api/user
+
+    [Test]
+    public async Task CreateUser_ReturnsCreatedUser()
+    {
+        var request = new CreateUserRequest("alice", "alice@test.local", "Pass123!", "Alice", "Smith", "learner", [1]);
+        _userService.CreateUserAsync(request).Returns(Alice);
+
+        var result = await _sut.CreateUser(request);
+
+        var createdResult = result.Result as CreatedAtActionResult;
+        Assert.That(createdResult, Is.Not.Null);
+        Assert.That(createdResult!.Value, Is.EqualTo(Alice));
+    }
+
+    [Test]
+    public async Task CreateUser_WhenServiceReturnsNull_ReturnsBadRequest()
+    {
+        var request = new CreateUserRequest("alice", "alice@test.local", "weak", "Alice", "Smith", "learner", []);
+        _userService.CreateUserAsync(request).Returns((UserDto?)null);
+
+        var result = await _sut.CreateUser(request);
+
+        Assert.That(result.Result, Is.TypeOf<BadRequestResult>());
+    }
+
+    // PUT /api/user/{id}/role
+
+    [Test]
+    public async Task AssignRole_WhenSucceeds_ReturnsNoContent()
+    {
+        _userService.AssignRoleAsync("id1", "manager").Returns(true);
+
+        var result = await _sut.AssignRole("id1", new AssignRoleRequest("manager"));
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task AssignRole_WhenUserNotFound_ReturnsNotFound()
+    {
+        _userService.AssignRoleAsync("missing", "manager").Returns(false);
+
+        var result = await _sut.AssignRole("missing", new AssignRoleRequest("manager"));
+
+        Assert.That(result, Is.TypeOf<NotFoundResult>());
+    }
+
+    // PUT /api/user/{id}/teams
+
+    [Test]
+    public async Task AssignTeams_WhenSucceeds_ReturnsNoContent()
+    {
+        _userService.AssignTeamsAsync("id1", [1, 2]).Returns(true);
+
+        var result = await _sut.AssignTeams("id1", new AssignTeamsRequest([1, 2]));
+
+        Assert.That(result, Is.TypeOf<NoContentResult>());
+    }
+
+    [Test]
+    public async Task AssignTeams_WhenUserNotFound_ReturnsNotFound()
+    {
+        _userService.AssignTeamsAsync("missing", []).Returns(false);
+
+        var result = await _sut.AssignTeams("missing", new AssignTeamsRequest([]));
+
+        Assert.That(result, Is.TypeOf<NotFoundResult>());
+    }
+}

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Controllers/UserController.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Controllers/UserController.cs
@@ -81,13 +81,13 @@ public class UserController : ControllerBase
     [Authorize(Roles = "backoffice")]
     public async Task<ActionResult<UserDto>> CreateUser(CreateUserRequest request)
     {
-        var user = await _userService.CreateUserAsync(request);
-        if (user == null)
+        var result = await _userService.CreateUserAsync(request);
+        if (!result.Succeeded)
         {
-            return BadRequest();
+            return BadRequest(result.Errors);
         }
 
-        return CreatedAtAction(nameof(GetUserById), new { userId = user.Id }, user);
+        return CreatedAtAction(nameof(GetUserById), new { userId = result.User!.Id }, result.User);
     }
 
     /// <summary>

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Controllers/UserController.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Controllers/UserController.cs
@@ -1,0 +1,114 @@
+using Itenium.SkillForge.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Itenium.SkillForge.WebApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class UserController : ControllerBase
+{
+    private readonly IUserService _userService;
+    private readonly ISkillForgeUser _currentUser;
+
+    public UserController(IUserService userService, ISkillForgeUser currentUser)
+    {
+        _userService = userService;
+        _currentUser = currentUser;
+    }
+
+    /// <summary>
+    /// Get users. Backoffice gets all users; managers get their team members; learners get only themselves.
+    /// </summary>
+    [HttpGet]
+    public async Task<ActionResult<IList<UserDto>>> GetUsers()
+    {
+        if (_currentUser.IsBackOffice)
+        {
+            return Ok(await _userService.GetAllUsersAsync());
+        }
+
+        if (_currentUser.Teams.Count > 0)
+        {
+            return Ok(await _userService.GetTeamMembersAsync(_currentUser.Teams.ToArray()));
+        }
+
+        var self = await _userService.GetUserByIdAsync(_currentUser.UserId!);
+        IList<UserDto> result = self == null ? [] : [self];
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Get the coaches of the current user's teams.
+    /// </summary>
+    [HttpGet("coach")]
+    public async Task<ActionResult<IList<UserDto>>> GetCoaches()
+    {
+        if (_currentUser.Teams.Count == 0)
+        {
+            return Ok(new List<UserDto>());
+        }
+
+        return Ok(await _userService.GetCoachesForTeamsAsync(_currentUser.Teams.ToArray()));
+    }
+
+    /// <summary>
+    /// Get the currently authenticated user's profile.
+    /// </summary>
+    [HttpGet("me")]
+    public async Task<ActionResult<UserDto>> GetCurrentUser()
+    {
+        var user = await _userService.GetUserByIdAsync(_currentUser.UserId!);
+        return user == null ? NotFound() : Ok(user);
+    }
+
+    /// <summary>
+    /// Get a user by ID (Admin only).
+    /// </summary>
+    [HttpGet("{userId}")]
+    [Authorize(Roles = "backoffice")]
+    public async Task<ActionResult<UserDto>> GetUserById(string userId)
+    {
+        var user = await _userService.GetUserByIdAsync(userId);
+        return user == null ? NotFound() : Ok(user);
+    }
+
+    /// <summary>
+    /// Create a new user account with role and team assignment (Admin only).
+    /// </summary>
+    [HttpPost]
+    [Authorize(Roles = "backoffice")]
+    public async Task<ActionResult<UserDto>> CreateUser(CreateUserRequest request)
+    {
+        var user = await _userService.CreateUserAsync(request);
+        if (user == null)
+        {
+            return BadRequest();
+        }
+
+        return CreatedAtAction(nameof(GetUserById), new { userId = user.Id }, user);
+    }
+
+    /// <summary>
+    /// Assign a role to a user (Admin only).
+    /// </summary>
+    [HttpPut("{userId}/role")]
+    [Authorize(Roles = "backoffice")]
+    public async Task<IActionResult> AssignRole(string userId, AssignRoleRequest request)
+    {
+        var success = await _userService.AssignRoleAsync(userId, request.Role);
+        return success ? NoContent() : NotFound();
+    }
+
+    /// <summary>
+    /// Assign team memberships to a user (Admin only).
+    /// </summary>
+    [HttpPut("{userId}/teams")]
+    [Authorize(Roles = "backoffice")]
+    public async Task<IActionResult> AssignTeams(string userId, AssignTeamsRequest request)
+    {
+        var success = await _userService.AssignTeamsAsync(userId, request.TeamIds);
+        return success ? NoContent() : NotFound();
+    }
+}

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Program.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/Program.cs
@@ -23,6 +23,7 @@ try
     builder.AddForgeOpenIddict<AppDbContext>(options => options.UseNpgsql(connectionString));
 
     builder.Services.AddScoped<ISkillForgeUser, SkillForgeUser>();
+    builder.Services.AddScoped<IUserService, UserService>();
 
     builder.AddForgeControllers();
     builder.AddForgeSwagger();

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/UserService.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/UserService.cs
@@ -1,0 +1,163 @@
+using System.Globalization;
+using System.Security.Claims;
+using Itenium.Forge.Security.OpenIddict;
+using Itenium.SkillForge.Services;
+using Microsoft.AspNetCore.Identity;
+
+namespace Itenium.SkillForge.WebApi;
+
+public class UserService : IUserService
+{
+    private readonly UserManager<ForgeUser> _userManager;
+
+    public UserService(UserManager<ForgeUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<IList<UserDto>> GetAllUsersAsync()
+    {
+        var users = _userManager.Users.ToList();
+        var result = new List<UserDto>();
+        foreach (var user in users)
+        {
+            result.Add(await ToDto(user));
+        }
+
+        return result;
+    }
+
+    public async Task<IList<UserDto>> GetTeamMembersAsync(int[] teamIds)
+    {
+        var found = new HashSet<ForgeUser>();
+        foreach (var teamId in teamIds)
+        {
+            var claim = new Claim("team", teamId.ToString(CultureInfo.InvariantCulture));
+            var users = await _userManager.GetUsersForClaimAsync(claim);
+            foreach (var user in users)
+            {
+                found.Add(user);
+            }
+        }
+
+        var result = new List<UserDto>();
+        foreach (var user in found)
+        {
+            result.Add(await ToDto(user));
+        }
+
+        return result;
+    }
+
+    public async Task<IList<UserDto>> GetCoachesForTeamsAsync(int[] teamIds)
+    {
+        var found = new HashSet<ForgeUser>();
+        foreach (var teamId in teamIds)
+        {
+            var claim = new Claim("team", teamId.ToString(CultureInfo.InvariantCulture));
+            var users = await _userManager.GetUsersForClaimAsync(claim);
+            foreach (var user in users)
+            {
+                var roles = await _userManager.GetRolesAsync(user);
+                if (roles.Contains("manager", StringComparer.Ordinal))
+                {
+                    found.Add(user);
+                }
+            }
+        }
+
+        var result = new List<UserDto>();
+        foreach (var user in found)
+        {
+            result.Add(await ToDto(user));
+        }
+
+        return result;
+    }
+
+    public async Task<UserDto?> GetUserByIdAsync(string userId)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        return user == null ? null : await ToDto(user);
+    }
+
+    public async Task<UserDto?> CreateUserAsync(CreateUserRequest request)
+    {
+        var user = new ForgeUser
+        {
+            UserName = request.UserName,
+            Email = request.Email,
+            EmailConfirmed = true,
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+        };
+
+        var result = await _userManager.CreateAsync(user, request.Password);
+        if (!result.Succeeded)
+        {
+            return null;
+        }
+
+        await _userManager.AddToRoleAsync(user, request.Role);
+        foreach (var teamId in request.Teams)
+        {
+            await _userManager.AddClaimAsync(user, new Claim("team", teamId.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return await ToDto(user);
+    }
+
+    public async Task<bool> AssignRoleAsync(string userId, string role)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user == null)
+        {
+            return false;
+        }
+
+        var currentRoles = await _userManager.GetRolesAsync(user);
+        await _userManager.RemoveFromRolesAsync(user, currentRoles);
+        await _userManager.AddToRoleAsync(user, role);
+        return true;
+    }
+
+    public async Task<bool> AssignTeamsAsync(string userId, int[] teamIds)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user == null)
+        {
+            return false;
+        }
+
+        var currentTeamClaims = (await _userManager.GetClaimsAsync(user))
+            .Where(c => c.Type == "team")
+            .ToList();
+        await _userManager.RemoveClaimsAsync(user, currentTeamClaims);
+
+        foreach (var teamId in teamIds)
+        {
+            await _userManager.AddClaimAsync(user, new Claim("team", teamId.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return true;
+    }
+
+    private async Task<UserDto> ToDto(ForgeUser user)
+    {
+        var roles = await _userManager.GetRolesAsync(user);
+        var claims = await _userManager.GetClaimsAsync(user);
+        var teams = claims
+            .Where(c => c.Type == "team")
+            .Select(c => int.Parse(c.Value, CultureInfo.InvariantCulture))
+            .ToArray();
+
+        return new UserDto(
+            user.Id,
+            user.UserName ?? string.Empty,
+            user.Email ?? string.Empty,
+            user.FirstName ?? string.Empty,
+            user.LastName ?? string.Empty,
+            roles.FirstOrDefault() ?? string.Empty,
+            teams);
+    }
+}

--- a/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/UserService.cs
+++ b/Itenium.SkillForge/backend/Itenium.SkillForge.WebApi/UserService.cs
@@ -81,7 +81,7 @@ public class UserService : IUserService
         return user == null ? null : await ToDto(user);
     }
 
-    public async Task<UserDto?> CreateUserAsync(CreateUserRequest request)
+    public async Task<CreateUserResult> CreateUserAsync(CreateUserRequest request)
     {
         var user = new ForgeUser
         {
@@ -95,7 +95,10 @@ public class UserService : IUserService
         var result = await _userManager.CreateAsync(user, request.Password);
         if (!result.Succeeded)
         {
-            return null;
+            var errors = result.Errors
+                .Select(e => new UserError(e.Code, e.Description))
+                .ToList();
+            return CreateUserResult.Failure(errors);
         }
 
         await _userManager.AddToRoleAsync(user, request.Role);
@@ -104,7 +107,7 @@ public class UserService : IUserService
             await _userManager.AddClaimAsync(user, new Claim("team", teamId.ToString(CultureInfo.InvariantCulture)));
         }
 
-        return await ToDto(user);
+        return CreateUserResult.Success(await ToDto(user));
     }
 
     public async Task<bool> AssignRoleAsync(string userId, string role)

--- a/Itenium.SkillForge/frontend/src/api/client.ts
+++ b/Itenium.SkillForge/frontend/src/api/client.ts
@@ -97,3 +97,26 @@ export async function fetchMyCoaches(): Promise<UserDto[]> {
   const response = await api.get<UserDto[]>('/api/user/coach');
   return response.data;
 }
+
+export interface CreateUserRequest {
+  userName: string;
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+  teams: number[];
+}
+
+export async function createUser(request: CreateUserRequest): Promise<UserDto> {
+  const response = await api.post<UserDto>('/api/user', request);
+  return response.data;
+}
+
+export async function updateUserRole(userId: string, role: string): Promise<void> {
+  await api.put(`/api/user/${userId}/role`, { role });
+}
+
+export async function updateUserTeams(userId: string, teamIds: number[]): Promise<void> {
+  await api.put(`/api/user/${userId}/teams`, { teamIds });
+}

--- a/Itenium.SkillForge/frontend/src/api/client.ts
+++ b/Itenium.SkillForge/frontend/src/api/client.ts
@@ -72,3 +72,28 @@ export async function fetchCourses(): Promise<Course[]> {
   const response = await api.get<Course[]>('/api/course');
   return response.data;
 }
+
+export interface UserDto {
+  id: string;
+  userName: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+  teams: number[];
+}
+
+export async function fetchUsers(): Promise<UserDto[]> {
+  const response = await api.get<UserDto[]>('/api/user');
+  return response.data;
+}
+
+export async function fetchCurrentUser(): Promise<UserDto> {
+  const response = await api.get<UserDto>('/api/user/me');
+  return response.data;
+}
+
+export async function fetchMyCoaches(): Promise<UserDto[]> {
+  const response = await api.get<UserDto[]>('/api/user/coach');
+  return response.data;
+}

--- a/Itenium.SkillForge/frontend/src/components/Layout.tsx
+++ b/Itenium.SkillForge/frontend/src/components/Layout.tsx
@@ -236,7 +236,7 @@ export function Layout() {
 
   // Team section - shown for managers
   const teamNavItems = [
-    { path: '/team/members', icon: Users, label: t('nav.teamMembers') },
+    { path: '/admin/users', icon: Users, label: t('nav.teamMembers') },
     { path: '/team/progress', icon: BarChart3, label: t('nav.teamProgress') },
     { path: '/team/assignments', icon: ClipboardList, label: t('nav.assignments') },
   ];

--- a/Itenium.SkillForge/frontend/src/components/__tests__/Layout.test.tsx
+++ b/Itenium.SkillForge/frontend/src/components/__tests__/Layout.test.tsx
@@ -114,6 +114,7 @@ function setupStores(options: {
       id: 'user-1',
       email: 'test@test.com',
       name: userName,
+      role: isBackOffice ? 'backoffice' : 'learner',
       isBackOffice,
     },
   });

--- a/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
+++ b/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
@@ -1,11 +1,66 @@
-import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
-import { Users, GraduationCap, Briefcase, Component } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle, Avatar, AvatarFallback } from '@itenium-forge/ui';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod/v4';
+import { Users, GraduationCap, Briefcase, Component, Plus, MoreHorizontal, Pencil, UserCheck } from 'lucide-react';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Avatar,
+  AvatarFallback,
+  Button,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetFooter,
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+  Input,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  Checkbox,
+} from '@itenium-forge/ui';
+import { toast } from 'sonner';
 import { useAuthStore } from '@/stores';
-import { fetchUsers, fetchCurrentUser, fetchMyCoaches, fetchUserTeams, type UserDto } from '@/api/client';
+import {
+  fetchUsers,
+  fetchCurrentUser,
+  fetchMyCoaches,
+  fetchUserTeams,
+  createUser,
+  updateUserRole,
+  updateUserTeams,
+  type UserDto,
+  type CreateUserRequest,
+} from '@/api/client';
 
-// ─── Role badge ──────────────────────────────────────────────────────────────
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Team {
+  id: number;
+  name: string;
+}
+
+// ─── Role badge ───────────────────────────────────────────────────────────────
 
 const roleMeta: Record<string, { label: string; className: string }> = {
   backoffice: { label: 'Admin', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' },
@@ -22,77 +77,492 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
-// ─── User row / card ─────────────────────────────────────────────────────────
+// ─── Create user sheet ────────────────────────────────────────────────────────
 
-function UserRow({ user, teamNames }: { user: UserDto; teamNames: Map<number, string> }) {
+const createUserSchema = z.object({
+  firstName: z.string().min(1, 'Required'),
+  lastName: z.string().min(1, 'Required'),
+  userName: z.string().min(1, 'Required'),
+  email: z.string().email('Invalid email'),
+  password: z.string().min(8, 'Min 8 characters'),
+  role: z.enum(['learner', 'manager', 'backoffice']),
+  teams: z.array(z.number()),
+});
+
+type CreateUserFormValues = z.infer<typeof createUserSchema>;
+
+function CreateUserSheet({
+  open,
+  onOpenChange,
+  defaultRole = 'learner',
+  teams,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  defaultRole?: 'learner' | 'manager' | 'backoffice';
+  teams: Team[];
+}) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const form = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: { firstName: '', lastName: '', userName: '', email: '', password: '', role: defaultRole, teams: [] },
+  });
+
+  const mutation = useMutation({
+    mutationFn: (values: CreateUserFormValues) => createUser(values as CreateUserRequest),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      toast.success(t('users.created', 'User created'));
+      form.reset();
+      onOpenChange(false);
+    },
+    onError: () => toast.error(t('users.createError', 'Failed to create user')),
+  });
+
+  const selectedTeams = form.watch('teams');
+  const selectedRole = form.watch('role');
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-[420px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>{t('users.createTitle', 'Create User')}</SheetTitle>
+          <SheetDescription>{t('users.createDesc', 'Add a new user to the platform.')}</SheetDescription>
+        </SheetHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit((v) => mutation.mutate(v))} className="space-y-4 py-4">
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="firstName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('users.firstName', 'First name')}</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="lastName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('users.lastName', 'Last name')}</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="userName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('users.username', 'Username')}</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('users.email', 'Email')}</FormLabel>
+                  <FormControl>
+                    <Input type="email" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('users.password', 'Password')}</FormLabel>
+                  <FormControl>
+                    <Input type="password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('users.role', 'Role')}</FormLabel>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="learner">Consultant</SelectItem>
+                      <SelectItem value="manager">Coach</SelectItem>
+                      <SelectItem value="backoffice">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {(selectedRole === 'manager' || selectedRole === 'learner') && teams.length > 0 && (
+              <FormField
+                control={form.control}
+                name="teams"
+                render={() => (
+                  <FormItem>
+                    <FormLabel>{t('users.teams', 'Teams')}</FormLabel>
+                    <div className="space-y-2">
+                      {teams.map((team) => (
+                        <div key={team.id} className="flex items-center gap-2">
+                          <Checkbox
+                            id={`team-${team.id}`}
+                            checked={selectedTeams.includes(team.id)}
+                            onCheckedChange={(checked) => {
+                              const current = form.getValues('teams');
+                              form.setValue(
+                                'teams',
+                                checked ? [...current, team.id] : current.filter((id) => id !== team.id),
+                              );
+                            }}
+                          />
+                          <label htmlFor={`team-${team.id}`} className="text-sm">
+                            {team.name}
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <SheetFooter className="pt-4">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                {t('common.cancel', 'Cancel')}
+              </Button>
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending ? t('common.saving', 'Saving…') : t('common.create', 'Create')}
+              </Button>
+            </SheetFooter>
+          </form>
+        </Form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── Edit user sheet (role + teams) ──────────────────────────────────────────
+
+const editUserSchema = z.object({
+  role: z.enum(['learner', 'manager', 'backoffice']),
+  teams: z.array(z.number()),
+});
+
+type EditUserFormValues = z.infer<typeof editUserSchema>;
+
+function EditUserSheet({
+  user,
+  teams,
+  onOpenChange,
+}: {
+  user: UserDto;
+  teams: Team[];
+  onOpenChange: (v: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const form = useForm<EditUserFormValues>({
+    resolver: zodResolver(editUserSchema),
+    defaultValues: {
+      role: (user.role as 'learner' | 'manager' | 'backoffice') ?? 'learner',
+      teams: user.teams,
+    },
+  });
+
+  const roleMutation = useMutation({
+    mutationFn: ({ role }: { role: string }) => updateUserRole(user.id, role),
+  });
+  const teamsMutation = useMutation({
+    mutationFn: ({ teamIds }: { teamIds: number[] }) => updateUserTeams(user.id, teamIds),
+  });
+
+  const onSubmit = async (values: EditUserFormValues) => {
+    try {
+      await Promise.all([
+        roleMutation.mutateAsync({ role: values.role }),
+        teamsMutation.mutateAsync({ teamIds: values.teams }),
+      ]);
+      queryClient.invalidateQueries({ queryKey: ['users'] });
+      toast.success(t('users.updated', 'User updated'));
+      onOpenChange(false);
+    } catch {
+      toast.error(t('users.updateError', 'Failed to update user'));
+    }
+  };
+
+  const selectedTeams = form.watch('teams');
+  const selectedRole = form.watch('role');
+  const isPending = roleMutation.isPending || teamsMutation.isPending;
+
+  return (
+    <Sheet open onOpenChange={onOpenChange}>
+      <SheetContent className="w-[420px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>
+            {user.firstName} {user.lastName}
+          </SheetTitle>
+          <SheetDescription>{user.email}</SheetDescription>
+        </SheetHeader>
+
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-4">
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t('users.role', 'Role')}</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="learner">Consultant</SelectItem>
+                      <SelectItem value="manager">Coach</SelectItem>
+                      <SelectItem value="backoffice">Admin</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {(selectedRole === 'manager' || selectedRole === 'learner') && teams.length > 0 && (
+              <FormField
+                control={form.control}
+                name="teams"
+                render={() => (
+                  <FormItem>
+                    <FormLabel>{t('users.teams', 'Teams')}</FormLabel>
+                    <div className="space-y-2">
+                      {teams.map((team) => (
+                        <div key={team.id} className="flex items-center gap-2">
+                          <Checkbox
+                            id={`edit-team-${team.id}`}
+                            checked={selectedTeams.includes(team.id)}
+                            onCheckedChange={(checked) => {
+                              const current = form.getValues('teams');
+                              form.setValue(
+                                'teams',
+                                checked ? [...current, team.id] : current.filter((id) => id !== team.id),
+                              );
+                            }}
+                          />
+                          <label htmlFor={`edit-team-${team.id}`} className="text-sm">
+                            {team.name}
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <SheetFooter className="pt-4">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                {t('common.cancel', 'Cancel')}
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
+              </Button>
+            </SheetFooter>
+          </form>
+        </Form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ─── User row with actions ────────────────────────────────────────────────────
+
+function UserRow({
+  user,
+  teamNames,
+  teams,
+  showActions,
+}: {
+  user: UserDto;
+  teamNames: Map<number, string>;
+  teams: Team[];
+  showActions: boolean;
+}) {
+  const [editOpen, setEditOpen] = useState(false);
   const initials = `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.toUpperCase();
   const teamLabels = user.teams.map((id) => teamNames.get(id) ?? `Team ${id}`).join(', ');
 
   return (
-    <div className="flex items-center gap-4 py-3 border-b last:border-0">
-      <Avatar className="size-9">
-        <AvatarFallback>{initials || user.userName.charAt(0).toUpperCase()}</AvatarFallback>
-      </Avatar>
-      <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium truncate">
-          {user.firstName} {user.lastName}
-        </p>
-        <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+    <>
+      <div className="flex items-center gap-4 py-3 border-b last:border-0">
+        <Avatar className="size-9">
+          <AvatarFallback>{initials || user.userName.charAt(0).toUpperCase()}</AvatarFallback>
+        </Avatar>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium truncate">
+            {user.firstName} {user.lastName}
+          </p>
+          <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {teamLabels && <span className="text-xs text-muted-foreground hidden sm:block">{teamLabels}</span>}
+          <RoleBadge role={user.role} />
+          {showActions && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm" className="size-8 p-0">
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => setEditOpen(true)}>
+                  <Pencil className="size-4 mr-2" />
+                  Edit role & teams
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
       </div>
-      <div className="flex items-center gap-2 shrink-0">
-        {teamLabels && <span className="text-xs text-muted-foreground hidden sm:block">{teamLabels}</span>}
-        <RoleBadge role={user.role} />
-      </div>
-    </div>
+
+      {editOpen && <EditUserSheet user={user} teams={teams} onOpenChange={setEditOpen} />}
+    </>
   );
 }
 
-// ─── Admin view: all users table ─────────────────────────────────────────────
+// ─── Admin view ───────────────────────────────────────────────────────────────
 
 function AdminView() {
   const { t } = useTranslation();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createRole, setCreateRole] = useState<'learner' | 'manager'>('learner');
+
   const { data: users = [], isLoading } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });
   const { data: teams = [] } = useQuery({ queryKey: ['teams'], queryFn: fetchUserTeams });
   const teamNames = new Map(teams.map((t) => [t.id, t.name]));
 
+  const coaches = users.filter((u) => u.role === 'manager');
+  const consultants = users.filter((u) => u.role === 'learner');
+
+  const openCreate = (role: 'learner' | 'manager') => {
+    setCreateRole(role);
+    setCreateOpen(true);
+  };
+
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <div className="flex size-10 items-center justify-center rounded-lg bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
-          <Briefcase className="size-5" />
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex size-10 items-center justify-center rounded-lg bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+            <Briefcase className="size-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold">{t('users.title', 'Users')}</h1>
+            <p className="text-sm text-muted-foreground">{isLoading ? '…' : `${users.length} total users`}</p>
+          </div>
         </div>
-        <div>
-          <h1 className="text-2xl font-bold">{t('users.title', 'Users')}</h1>
-          <p className="text-sm text-muted-foreground">
-            {isLoading
-              ? '…'
-              : t('users.adminSubtitle', { count: users.length, defaultValue: `${users.length} total users` })}
-          </p>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => openCreate('manager')}>
+            <UserCheck className="size-4 mr-2" />
+            {t('users.addCoach', 'Add Coach')}
+          </Button>
+          <Button onClick={() => openCreate('learner')}>
+            <Plus className="size-4 mr-2" />
+            {t('users.addUser', 'Add User')}
+          </Button>
         </div>
       </div>
 
+      {/* Coaches */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
-            <Users className="size-4" />
-            {t('users.allUsers', 'All Users')}
+            <UserCheck className="size-4" />
+            {t('users.coaches', 'Coaches')}
+            <span className="ml-auto text-xs font-normal text-muted-foreground">{coaches.length}</span>
           </CardTitle>
         </CardHeader>
         <CardContent>
           {isLoading ? (
             <p className="text-sm text-muted-foreground py-4 text-center">{t('common.loading', 'Loading…')}</p>
-          ) : users.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">{t('users.empty', 'No users found')}</p>
+          ) : coaches.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">{t('users.noCoaches', 'No coaches yet')}</p>
           ) : (
-            users.map((user) => <UserRow key={user.id} user={user} teamNames={teamNames} />)
+            coaches.map((user) => <UserRow key={user.id} user={user} teamNames={teamNames} teams={teams} showActions />)
           )}
         </CardContent>
       </Card>
+
+      {/* Consultants */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Users className="size-4" />
+            {t('users.consultants', 'Consultants')}
+            <span className="ml-auto text-xs font-normal text-muted-foreground">{consultants.length}</span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">{t('common.loading', 'Loading…')}</p>
+          ) : consultants.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              {t('users.noConsultants', 'No consultants yet')}
+            </p>
+          ) : (
+            consultants.map((user) => (
+              <UserRow key={user.id} user={user} teamNames={teamNames} teams={teams} showActions />
+            ))
+          )}
+        </CardContent>
+      </Card>
+
+      <CreateUserSheet open={createOpen} onOpenChange={setCreateOpen} defaultRole={createRole} teams={teams} />
     </div>
   );
 }
 
-// ─── Coach view: teams with their members ────────────────────────────────────
+// ─── Coach view ───────────────────────────────────────────────────────────────
 
 function CoachView() {
   const { t } = useTranslation();
@@ -108,12 +578,7 @@ function CoachView() {
         </div>
         <div>
           <h1 className="text-2xl font-bold">{t('users.myTeams', 'My Teams')}</h1>
-          <p className="text-sm text-muted-foreground">
-            {t('users.coachSubtitle', {
-              count: users.length,
-              defaultValue: `${users.length} members across your teams`,
-            })}
-          </p>
+          <p className="text-sm text-muted-foreground">{`${users.length} members across your teams`}</p>
         </div>
       </div>
 
@@ -137,7 +602,9 @@ function CoachView() {
                     {t('users.noMembers', 'No members in this team')}
                   </p>
                 ) : (
-                  members.map((user) => <UserRow key={user.id} user={user} teamNames={teamNames} />)
+                  members.map((user) => (
+                    <UserRow key={user.id} user={user} teamNames={teamNames} teams={[]} showActions={false} />
+                  ))
                 )}
               </CardContent>
             </Card>
@@ -148,7 +615,7 @@ function CoachView() {
   );
 }
 
-// ─── Learner view: own profile + coach ───────────────────────────────────────
+// ─── Learner view ─────────────────────────────────────────────────────────────
 
 function ProfileCard({ user, teamNames, label }: { user: UserDto; teamNames: Map<number, string>; label: string }) {
   const initials = `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.toUpperCase();
@@ -228,7 +695,7 @@ function LearnerView() {
   );
 }
 
-// ─── Main export ─────────────────────────────────────────────────────────────
+// ─── Main export ──────────────────────────────────────────────────────────────
 
 export function UsersPage() {
   const { user } = useAuthStore();

--- a/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
+++ b/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
@@ -4,7 +4,17 @@ import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod/v4';
-import { Users, GraduationCap, Briefcase, Component, Plus, MoreHorizontal, Pencil, UserCheck } from 'lucide-react';
+import {
+  Users,
+  GraduationCap,
+  Briefcase,
+  Component,
+  Plus,
+  MoreHorizontal,
+  Pencil,
+  UserCheck,
+  UserPlus,
+} from 'lucide-react';
 import {
   Card,
   CardContent,
@@ -12,7 +22,9 @@ import {
   CardTitle,
   Avatar,
   AvatarFallback,
+  Badge,
   Button,
+  Separator,
   Sheet,
   SheetContent,
   SheetHeader,
@@ -63,17 +75,28 @@ interface Team {
 // ─── Role badge ───────────────────────────────────────────────────────────────
 
 const roleMeta: Record<string, { label: string; className: string }> = {
-  backoffice: { label: 'Admin', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' },
-  manager: { label: 'Coach', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' },
-  learner: { label: 'Consultant', className: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
+  backoffice: {
+    label: 'Admin',
+    className:
+      'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200 border-purple-200 dark:border-purple-800',
+  },
+  manager: {
+    label: 'Coach',
+    className: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200 border-blue-200 dark:border-blue-800',
+  },
+  learner: {
+    label: 'Consultant',
+    className:
+      'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200 border-green-200 dark:border-green-800',
+  },
 };
 
 function RoleBadge({ role }: { role: string }) {
   const meta = roleMeta[role] ?? { label: role, className: 'bg-gray-100 text-gray-800' };
   return (
-    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${meta.className}`}>
+    <Badge variant="outline" className={meta.className}>
       {meta.label}
-    </span>
+    </Badge>
   );
 }
 
@@ -118,7 +141,20 @@ function CreateUserSheet({
       form.reset();
       onOpenChange(false);
     },
-    onError: () => toast.error(t('users.createError', 'Failed to create user')),
+    onError: (error: unknown) => {
+      const data = (error as { response?: { data?: unknown } })?.response?.data;
+      let detail = '';
+      if (Array.isArray(data)) {
+        // ASP.NET Identity errors: [{ code, description }]
+        detail = (data as { description?: string; code?: string }[])
+          .map((e) => e.description ?? e.code ?? '')
+          .filter(Boolean)
+          .join('\n');
+      } else if (typeof data === 'string') {
+        detail = data;
+      }
+      toast.error(t('users.createError', 'Failed to create user'), { description: detail || undefined });
+    },
   });
 
   const selectedTeams = form.watch('teams');
@@ -126,21 +162,71 @@ function CreateUserSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-[420px] overflow-y-auto">
-        <SheetHeader>
-          <SheetTitle>{t('users.createTitle', 'Create User')}</SheetTitle>
-          <SheetDescription>{t('users.createDesc', 'Add a new user to the platform.')}</SheetDescription>
+      <SheetContent className="w-[420px] overflow-y-auto px-6">
+        <SheetHeader className="pb-4 pt-2">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <UserPlus className="size-5" />
+            </div>
+            <div>
+              <SheetTitle>{t('users.createTitle', 'Create User')}</SheetTitle>
+              <SheetDescription>{t('users.createDesc', 'Add a new user to the platform.')}</SheetDescription>
+            </div>
+          </div>
         </SheetHeader>
 
+        <Separator />
+
         <Form {...form}>
-          <form onSubmit={form.handleSubmit((v) => mutation.mutate(v))} className="space-y-4 py-4">
-            <div className="grid grid-cols-2 gap-3">
+          <form onSubmit={form.handleSubmit((v) => mutation.mutate(v))} className="space-y-6 py-4">
+            {/* Personal information */}
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {t('users.sectionPersonal', 'Personal information')}
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                <FormField
+                  control={form.control}
+                  name="firstName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('users.firstName', 'First name')}</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="lastName"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('users.lastName', 'Last name')}</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+
+            <Separator />
+
+            {/* Account */}
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {t('users.sectionAccount', 'Account')}
+              </p>
               <FormField
                 control={form.control}
-                name="firstName"
+                name="userName"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{t('users.firstName', 'First name')}</FormLabel>
+                    <FormLabel>{t('users.username', 'Username')}</FormLabel>
                     <FormControl>
                       <Input {...field} />
                     </FormControl>
@@ -150,12 +236,25 @@ function CreateUserSheet({
               />
               <FormField
                 control={form.control}
-                name="lastName"
+                name="email"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{t('users.lastName', 'Last name')}</FormLabel>
+                    <FormLabel>{t('users.email', 'Email')}</FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <Input type="email" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t('users.password', 'Password')}</FormLabel>
+                    <FormControl>
+                      <Input type="password" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -163,105 +262,76 @@ function CreateUserSheet({
               />
             </div>
 
-            <FormField
-              control={form.control}
-              name="userName"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('users.username', 'Username')}</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <Separator />
 
-            <FormField
-              control={form.control}
-              name="email"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('users.email', 'Email')}</FormLabel>
-                  <FormControl>
-                    <Input type="email" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="password"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('users.password', 'Password')}</FormLabel>
-                  <FormControl>
-                    <Input type="password" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="role"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('users.role', 'Role')}</FormLabel>
-                  <Select onValueChange={field.onChange} defaultValue={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="learner">Consultant</SelectItem>
-                      <SelectItem value="manager">Coach</SelectItem>
-                      <SelectItem value="backoffice">Admin</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {(selectedRole === 'manager' || selectedRole === 'learner') && teams.length > 0 && (
+            {/* Access */}
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {t('users.sectionAccess', 'Access')}
+              </p>
               <FormField
                 control={form.control}
-                name="teams"
-                render={() => (
+                name="role"
+                render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{t('users.teams', 'Teams')}</FormLabel>
-                    <div className="space-y-2">
-                      {teams.map((team) => (
-                        <div key={team.id} className="flex items-center gap-2">
-                          <Checkbox
-                            id={`team-${team.id}`}
-                            checked={selectedTeams.includes(team.id)}
-                            onCheckedChange={(checked) => {
-                              const current = form.getValues('teams');
-                              form.setValue(
-                                'teams',
-                                checked ? [...current, team.id] : current.filter((id) => id !== team.id),
-                              );
-                            }}
-                          />
-                          <label htmlFor={`team-${team.id}`} className="text-sm">
-                            {team.name}
-                          </label>
-                        </div>
-                      ))}
-                    </div>
+                    <FormLabel>{t('users.role', 'Role')}</FormLabel>
+                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="learner">Consultant</SelectItem>
+                        <SelectItem value="manager">Coach</SelectItem>
+                        <SelectItem value="backoffice">Admin</SelectItem>
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            )}
 
-            <SheetFooter className="pt-4">
+              {(selectedRole === 'manager' || selectedRole === 'learner') && teams.length > 0 && (
+                <FormField
+                  control={form.control}
+                  name="teams"
+                  render={() => (
+                    <FormItem>
+                      <FormLabel>{t('users.teams', 'Teams')}</FormLabel>
+                      <div className="rounded-lg border p-3 space-y-2.5">
+                        {teams.map((team) => (
+                          <div key={team.id} className="flex items-center gap-2.5">
+                            <Checkbox
+                              id={`team-${team.id}`}
+                              checked={selectedTeams.includes(team.id)}
+                              onCheckedChange={(checked) => {
+                                const current = form.getValues('teams');
+                                form.setValue(
+                                  'teams',
+                                  checked ? [...current, team.id] : current.filter((id) => id !== team.id),
+                                );
+                              }}
+                            />
+                            <label
+                              htmlFor={`team-${team.id}`}
+                              className="text-sm font-medium leading-none cursor-pointer"
+                            >
+                              {team.name}
+                            </label>
+                          </div>
+                        ))}
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+
+            <Separator />
+
+            <SheetFooter>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                 {t('common.cancel', 'Cancel')}
               </Button>
@@ -330,75 +400,97 @@ function EditUserSheet({
   const selectedRole = form.watch('role');
   const isPending = roleMutation.isPending || teamsMutation.isPending;
 
+  const initials = `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.toUpperCase();
+
   return (
     <Sheet open onOpenChange={onOpenChange}>
-      <SheetContent className="w-[420px] overflow-y-auto">
-        <SheetHeader>
-          <SheetTitle>
-            {user.firstName} {user.lastName}
-          </SheetTitle>
-          <SheetDescription>{user.email}</SheetDescription>
+      <SheetContent className="w-[420px] overflow-y-auto px-6">
+        <SheetHeader className="pb-4 pt-2">
+          <div className="flex items-center gap-3">
+            <Avatar className="size-12">
+              <AvatarFallback className="text-base">{initials || user.userName.charAt(0).toUpperCase()}</AvatarFallback>
+            </Avatar>
+            <div className="flex-1 min-w-0">
+              <SheetTitle className="flex items-center gap-2">
+                {user.firstName} {user.lastName}
+                <RoleBadge role={user.role} />
+              </SheetTitle>
+              <SheetDescription className="truncate">{user.email}</SheetDescription>
+            </div>
+          </div>
         </SheetHeader>
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-4">
-            <FormField
-              control={form.control}
-              name="role"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t('users.role', 'Role')}</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="learner">Consultant</SelectItem>
-                      <SelectItem value="manager">Coach</SelectItem>
-                      <SelectItem value="backoffice">Admin</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+        <Separator />
 
-            {(selectedRole === 'manager' || selectedRole === 'learner') && teams.length > 0 && (
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 py-4">
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                {t('users.sectionAccess', 'Access')}
+              </p>
               <FormField
                 control={form.control}
-                name="teams"
-                render={() => (
+                name="role"
+                render={({ field }) => (
                   <FormItem>
-                    <FormLabel>{t('users.teams', 'Teams')}</FormLabel>
-                    <div className="space-y-2">
-                      {teams.map((team) => (
-                        <div key={team.id} className="flex items-center gap-2">
-                          <Checkbox
-                            id={`edit-team-${team.id}`}
-                            checked={selectedTeams.includes(team.id)}
-                            onCheckedChange={(checked) => {
-                              const current = form.getValues('teams');
-                              form.setValue(
-                                'teams',
-                                checked ? [...current, team.id] : current.filter((id) => id !== team.id),
-                              );
-                            }}
-                          />
-                          <label htmlFor={`edit-team-${team.id}`} className="text-sm">
-                            {team.name}
-                          </label>
-                        </div>
-                      ))}
-                    </div>
+                    <FormLabel>{t('users.role', 'Role')}</FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="learner">Consultant</SelectItem>
+                        <SelectItem value="manager">Coach</SelectItem>
+                        <SelectItem value="backoffice">Admin</SelectItem>
+                      </SelectContent>
+                    </Select>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            )}
 
-            <SheetFooter className="pt-4">
+              {(selectedRole === 'manager' || selectedRole === 'learner') && teams.length > 0 && (
+                <FormField
+                  control={form.control}
+                  name="teams"
+                  render={() => (
+                    <FormItem>
+                      <FormLabel>{t('users.teams', 'Teams')}</FormLabel>
+                      <div className="rounded-lg border p-3 space-y-2.5">
+                        {teams.map((team) => (
+                          <div key={team.id} className="flex items-center gap-2.5">
+                            <Checkbox
+                              id={`edit-team-${team.id}`}
+                              checked={selectedTeams.includes(team.id)}
+                              onCheckedChange={(checked) => {
+                                const current = form.getValues('teams');
+                                form.setValue(
+                                  'teams',
+                                  checked ? [...current, team.id] : current.filter((id) => id !== team.id),
+                                );
+                              }}
+                            />
+                            <label
+                              htmlFor={`edit-team-${team.id}`}
+                              className="text-sm font-medium leading-none cursor-pointer"
+                            >
+                              {team.name}
+                            </label>
+                          </div>
+                        ))}
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+
+            <Separator />
+
+            <SheetFooter>
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                 {t('common.cancel', 'Cancel')}
               </Button>

--- a/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
+++ b/Itenium.SkillForge/frontend/src/pages/UsersPage.tsx
@@ -1,0 +1,239 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { Users, GraduationCap, Briefcase, Component } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, Avatar, AvatarFallback } from '@itenium-forge/ui';
+import { useAuthStore } from '@/stores';
+import { fetchUsers, fetchCurrentUser, fetchMyCoaches, fetchUserTeams, type UserDto } from '@/api/client';
+
+// ─── Role badge ──────────────────────────────────────────────────────────────
+
+const roleMeta: Record<string, { label: string; className: string }> = {
+  backoffice: { label: 'Admin', className: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200' },
+  manager: { label: 'Coach', className: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200' },
+  learner: { label: 'Consultant', className: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' },
+};
+
+function RoleBadge({ role }: { role: string }) {
+  const meta = roleMeta[role] ?? { label: role, className: 'bg-gray-100 text-gray-800' };
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${meta.className}`}>
+      {meta.label}
+    </span>
+  );
+}
+
+// ─── User row / card ─────────────────────────────────────────────────────────
+
+function UserRow({ user, teamNames }: { user: UserDto; teamNames: Map<number, string> }) {
+  const initials = `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.toUpperCase();
+  const teamLabels = user.teams.map((id) => teamNames.get(id) ?? `Team ${id}`).join(', ');
+
+  return (
+    <div className="flex items-center gap-4 py-3 border-b last:border-0">
+      <Avatar className="size-9">
+        <AvatarFallback>{initials || user.userName.charAt(0).toUpperCase()}</AvatarFallback>
+      </Avatar>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">
+          {user.firstName} {user.lastName}
+        </p>
+        <p className="text-xs text-muted-foreground truncate">{user.email}</p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {teamLabels && <span className="text-xs text-muted-foreground hidden sm:block">{teamLabels}</span>}
+        <RoleBadge role={user.role} />
+      </div>
+    </div>
+  );
+}
+
+// ─── Admin view: all users table ─────────────────────────────────────────────
+
+function AdminView() {
+  const { t } = useTranslation();
+  const { data: users = [], isLoading } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });
+  const { data: teams = [] } = useQuery({ queryKey: ['teams'], queryFn: fetchUserTeams });
+  const teamNames = new Map(teams.map((t) => [t.id, t.name]));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
+          <Briefcase className="size-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold">{t('users.title', 'Users')}</h1>
+          <p className="text-sm text-muted-foreground">
+            {isLoading
+              ? '…'
+              : t('users.adminSubtitle', { count: users.length, defaultValue: `${users.length} total users` })}
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Users className="size-4" />
+            {t('users.allUsers', 'All Users')}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">{t('common.loading', 'Loading…')}</p>
+          ) : users.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">{t('users.empty', 'No users found')}</p>
+          ) : (
+            users.map((user) => <UserRow key={user.id} user={user} teamNames={teamNames} />)
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Coach view: teams with their members ────────────────────────────────────
+
+function CoachView() {
+  const { t } = useTranslation();
+  const { data: users = [], isLoading } = useQuery({ queryKey: ['users'], queryFn: fetchUsers });
+  const { data: teams = [] } = useQuery({ queryKey: ['teams'], queryFn: fetchUserTeams });
+  const teamNames = new Map(teams.map((t) => [t.id, t.name]));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+          <Component className="size-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold">{t('users.myTeams', 'My Teams')}</h1>
+          <p className="text-sm text-muted-foreground">
+            {t('users.coachSubtitle', {
+              count: users.length,
+              defaultValue: `${users.length} members across your teams`,
+            })}
+          </p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">{t('common.loading', 'Loading…')}</p>
+      ) : (
+        teams.map((team) => {
+          const members = users.filter((u) => u.teams.includes(team.id));
+          return (
+            <Card key={team.id}>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Component className="size-4" />
+                  {team.name}
+                  <span className="ml-auto text-xs font-normal text-muted-foreground">{members.length} members</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {members.length === 0 ? (
+                  <p className="text-sm text-muted-foreground py-2">
+                    {t('users.noMembers', 'No members in this team')}
+                  </p>
+                ) : (
+                  members.map((user) => <UserRow key={user.id} user={user} teamNames={teamNames} />)
+                )}
+              </CardContent>
+            </Card>
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+// ─── Learner view: own profile + coach ───────────────────────────────────────
+
+function ProfileCard({ user, teamNames, label }: { user: UserDto; teamNames: Map<number, string>; label: string }) {
+  const initials = `${user.firstName.charAt(0)}${user.lastName.charAt(0)}`.toUpperCase();
+  const teamLabels = user.teams.map((id) => teamNames.get(id) ?? `Team ${id}`).join(', ');
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm text-muted-foreground font-normal">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-4">
+          <Avatar className="size-12">
+            <AvatarFallback className="text-lg">{initials || user.userName.charAt(0).toUpperCase()}</AvatarFallback>
+          </Avatar>
+          <div className="flex-1">
+            <p className="font-semibold">
+              {user.firstName} {user.lastName}
+            </p>
+            <p className="text-sm text-muted-foreground">{user.email}</p>
+            {teamLabels && <p className="text-sm text-muted-foreground mt-1">{teamLabels}</p>}
+          </div>
+          <RoleBadge role={user.role} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LearnerView() {
+  const { t } = useTranslation();
+  const { data: me, isLoading: meLoading } = useQuery({ queryKey: ['user-me'], queryFn: fetchCurrentUser });
+  const { data: coaches = [], isLoading: coachesLoading } = useQuery({
+    queryKey: ['coaches'],
+    queryFn: fetchMyCoaches,
+  });
+  const { data: teams = [] } = useQuery({ queryKey: ['teams'], queryFn: fetchUserTeams });
+  const teamNames = new Map(teams.map((t) => [t.id, t.name]));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+          <GraduationCap className="size-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold">{t('users.myProfile', 'My Profile')}</h1>
+          <p className="text-sm text-muted-foreground">
+            {t('users.learnerSubtitle', 'Your profile and assigned coach')}
+          </p>
+        </div>
+      </div>
+
+      {meLoading ? (
+        <p className="text-sm text-muted-foreground">{t('common.loading', 'Loading…')}</p>
+      ) : me ? (
+        <ProfileCard user={me} teamNames={teamNames} label={t('users.you', 'You')} />
+      ) : null}
+
+      {coachesLoading ? null : coaches.length > 0 ? (
+        <div className="space-y-3">
+          <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            {t('users.yourCoach', 'Your Coach')}
+          </h2>
+          {coaches.map((coach) => (
+            <ProfileCard key={coach.id} user={coach} teamNames={teamNames} label={t('users.coach', 'Coach')} />
+          ))}
+        </div>
+      ) : (
+        <Card>
+          <CardContent className="py-8 text-center text-sm text-muted-foreground">
+            {t('users.noCoach', 'No coach assigned yet')}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ─── Main export ─────────────────────────────────────────────────────────────
+
+export function UsersPage() {
+  const { user } = useAuthStore();
+
+  if (user?.role === 'backoffice') return <AdminView />;
+  if (user?.role === 'manager') return <CoachView />;
+  return <LearnerView />;
+}

--- a/Itenium.SkillForge/frontend/src/routeTree.gen.ts
+++ b/Itenium.SkillForge/frontend/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
 import { Route as AuthenticatedCoursesRouteImport } from './routes/_authenticated/courses'
 import { Route as authSignInRouteImport } from './routes/(auth)/sign-in'
+import { Route as AuthenticatedAdminUsersRouteImport } from './routes/_authenticated/admin/users'
 
 const AuthenticatedRouteRoute = AuthenticatedRouteRouteImport.update({
   id: '/_authenticated',
@@ -39,18 +40,25 @@ const authSignInRoute = authSignInRouteImport.update({
   path: '/sign-in',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedAdminUsersRoute = AuthenticatedAdminUsersRouteImport.update({
+  id: '/admin/users',
+  path: '/admin/users',
+  getParentRoute: () => AuthenticatedRouteRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/sign-in': typeof authSignInRoute
   '/courses': typeof AuthenticatedCoursesRoute
   '/settings': typeof AuthenticatedSettingsRoute
   '/': typeof AuthenticatedIndexRoute
+  '/admin/users': typeof AuthenticatedAdminUsersRoute
 }
 export interface FileRoutesByTo {
   '/sign-in': typeof authSignInRoute
   '/courses': typeof AuthenticatedCoursesRoute
   '/settings': typeof AuthenticatedSettingsRoute
   '/': typeof AuthenticatedIndexRoute
+  '/admin/users': typeof AuthenticatedAdminUsersRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -59,12 +67,13 @@ export interface FileRoutesById {
   '/_authenticated/courses': typeof AuthenticatedCoursesRoute
   '/_authenticated/settings': typeof AuthenticatedSettingsRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
+  '/_authenticated/admin/users': typeof AuthenticatedAdminUsersRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/sign-in' | '/courses' | '/settings' | '/'
+  fullPaths: '/sign-in' | '/courses' | '/settings' | '/' | '/admin/users'
   fileRoutesByTo: FileRoutesByTo
-  to: '/sign-in' | '/courses' | '/settings' | '/'
+  to: '/sign-in' | '/courses' | '/settings' | '/' | '/admin/users'
   id:
     | '__root__'
     | '/_authenticated'
@@ -72,6 +81,7 @@ export interface FileRouteTypes {
     | '/_authenticated/courses'
     | '/_authenticated/settings'
     | '/_authenticated/'
+    | '/_authenticated/admin/users'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -116,6 +126,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof authSignInRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/admin/users': {
+      id: '/_authenticated/admin/users'
+      path: '/admin/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AuthenticatedAdminUsersRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
   }
 }
 
@@ -123,12 +140,14 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedCoursesRoute: typeof AuthenticatedCoursesRoute
   AuthenticatedSettingsRoute: typeof AuthenticatedSettingsRoute
   AuthenticatedIndexRoute: typeof AuthenticatedIndexRoute
+  AuthenticatedAdminUsersRoute: typeof AuthenticatedAdminUsersRoute
 }
 
 const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedCoursesRoute: AuthenticatedCoursesRoute,
   AuthenticatedSettingsRoute: AuthenticatedSettingsRoute,
   AuthenticatedIndexRoute: AuthenticatedIndexRoute,
+  AuthenticatedAdminUsersRoute: AuthenticatedAdminUsersRoute,
 }
 
 const AuthenticatedRouteRouteWithChildren =

--- a/Itenium.SkillForge/frontend/src/routes/_authenticated/admin/users.tsx
+++ b/Itenium.SkillForge/frontend/src/routes/_authenticated/admin/users.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { UsersPage } from '@/pages/UsersPage';
+
+export const Route = createFileRoute('/_authenticated/admin/users')({
+  component: UsersPage,
+});

--- a/Itenium.SkillForge/frontend/src/stores/__tests__/authStore.test.ts
+++ b/Itenium.SkillForge/frontend/src/stores/__tests__/authStore.test.ts
@@ -40,6 +40,7 @@ describe('useAuthStore', () => {
         id: 'user-123',
         name: 'Alice',
         email: 'alice@example.com',
+        role: 'backoffice',
         isBackOffice: true,
       });
     });

--- a/Itenium.SkillForge/frontend/src/stores/authStore.ts
+++ b/Itenium.SkillForge/frontend/src/stores/authStore.ts
@@ -85,9 +85,14 @@ export const useAuthStore = create<AuthState>()(
     {
       name: 'auth-storage',
       onRehydrateStorage: () => (state) => {
-        // Check if token is expired on rehydration
-        if (state?.accessToken && isTokenExpired(state.accessToken)) {
+        if (!state?.accessToken) return;
+        if (isTokenExpired(state.accessToken)) {
           state.logout();
+          return;
+        }
+        // Re-parse user from token if role field is missing (schema migration)
+        if (!state.user?.role) {
+          state.setToken(state.accessToken);
         }
       },
     },

--- a/Itenium.SkillForge/frontend/src/stores/authStore.ts
+++ b/Itenium.SkillForge/frontend/src/stores/authStore.ts
@@ -15,6 +15,7 @@ interface User {
   id: string;
   email: string;
   name: string;
+  role: 'backoffice' | 'manager' | 'learner';
   isBackOffice: boolean;
 }
 
@@ -26,14 +27,22 @@ interface AuthState {
   logout: () => void;
 }
 
+function parseRole(decoded: JwtPayload): 'backoffice' | 'manager' | 'learner' {
+  const roles = Array.isArray(decoded.role) ? decoded.role : decoded.role ? [decoded.role] : [];
+  if (roles.includes('backoffice')) return 'backoffice';
+  if (roles.includes('manager')) return 'manager';
+  return 'learner';
+}
+
 function parseUserFromToken(token: string): User {
   const decoded = jwtDecode<JwtPayload>(token);
-  const roles = Array.isArray(decoded.role) ? decoded.role : decoded.role ? [decoded.role] : [];
+  const role = parseRole(decoded);
   return {
     id: decoded.sub,
     email: decoded.email || decoded.preferred_username || '',
     name: decoded.name || decoded.preferred_username || 'User',
-    isBackOffice: roles.includes('backoffice'),
+    role,
+    isBackOffice: role === 'backoffice',
   };
 }
 


### PR DESCRIPTION
Backend:
- Add IUserService, UserService wrapping UserManager<ForgeUser>
- Add UserController with role-aware GET /api/user endpoint: backoffice returns all users, manager returns team members, learner returns self
- Add GET /api/user/me (current user profile, all roles)
- Add GET /api/user/{id} (admin only)
- Add GET /api/user/coach (learner's coach from same team)
- Add POST /api/user, PUT /api/user/{id}/role, PUT /api/user/{id}/teams (admin only)
- Register IUserService in DI
- Assign learner seed user to Java team so they have a coach

Frontend:
- Add role field ('backoffice'|'manager'|'learner') to User type in authStore
- Add fetchUsers, fetchCurrentUser, fetchMyCoaches to API client
- Create /admin/users route with role-aware UsersPage: admin sees all users table, coach sees teams+members, learner sees self+coach
- Update Team Members nav link to point to /admin/users for coaches